### PR TITLE
apng-viewのお試し実装

### DIFF
--- a/app/src/main/java/com/github/sahasbhop/apngview/sample/MainActivity.java
+++ b/app/src/main/java/com/github/sahasbhop/apngview/sample/MainActivity.java
@@ -4,6 +4,10 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
+import android.widget.ImageView;
+
+import com.github.sahasbhop.apngview.ApngDrawable;
+import com.github.sahasbhop.apngview.ApngImageLoader;
 
 public class MainActivity extends AppCompatActivity implements View.OnClickListener {
 
@@ -14,6 +18,24 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
         findViewById(R.id.button_view_pager).setOnClickListener(this);
         findViewById(R.id.button_list_view).setOnClickListener(this);
+
+        ImageView imageView = (ImageView) findViewById(R.id.image_view);
+        imageView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                ApngDrawable drawable = ApngDrawable.getFromView(view);
+                boolean isStart = !drawable.isRunning();
+
+                if (isStart) {
+                    drawable.start();
+                } else {
+                    drawable.stop();
+                }
+            }
+        });
+        ApngImageLoader.getInstance().displayApng("http://ics-web.jp/lab-data/140930_apng/images/elephant_apng_zopfli.png",
+            imageView,
+            new ApngImageLoader.ApngConfig(0, true, false));
     }
 
     @Override

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -21,4 +21,10 @@
         android:text="List View"
         android:textSize="16sp" />
 
+    <ImageView
+        android:id="@+id/image_view"
+        android:layout_marginTop="16dp"
+        android:layout_width="200dp"
+        android:layout_height="200dp"
+        />
 </LinearLayout>


### PR DESCRIPTION
apng-viewライブラリの使い勝手を簡易に評価する目的で、サンプルアプリのトップ画面にネット上のAPNG画像を表示してみました。

![apng_record](https://user-images.githubusercontent.com/40755166/61700136-27aeee80-ad77-11e9-8644-0d05faabf506.gif)

アプリでは http://ics-web.jp/lab-data/140930_apng/sample1/ においてあるapngを読み込んで表示しています。

![](http://ics-web.jp/lab-data/140930_apng/images/elephant_apng_zopfli.png)

---

- ライセンスはApache 2.0なので問題ない
- ここ３年ほど開発されていないのが懸念点
- Star数は90強なので、あまりメジャーな用途でないことを考慮すると、こちらは問題なさそう
- フットプリントは本体が350KB程度で、Universal Image Loaderが150KB程度なので、合計で500KBくらい